### PR TITLE
ci: refresh SmartClipboard workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v6 to v7 in all CI jobs.
- Bump `pnpm/action-setup` from v4 to v6 in the frontend job.
- Leave the existing `undici` override/lockfile state intact; current `main` already resolves `undici@7.28.0`.

## Verification
- Confirmed stale Dependabot PRs #43/#44 fail on the old `undici <7.28.0` audit path, not on the action bump itself.
- Local dependency install was blocked by the Codex app policy, so this PR should be CI-gated before merge.

Supersedes the action portions of #43 and #44 without mutating Dependabot branches.